### PR TITLE
Stop four render tests from reading the developer's terminal

### DIFF
--- a/src/render/frame.rs
+++ b/src/render/frame.rs
@@ -1367,9 +1367,25 @@ mod tests {
 
     fn app_with(text: &str) -> App {
         let mut app = App::new(Config::default(), None, None).unwrap();
+        pin_theme(&mut app);
         app.buffer.insert_str(Cursor::new(0, 0), text);
         app.blocks = BlockCache::build(&app.buffer);
         app
+    }
+
+    /// Give the app the palette AS AUTHORED, instead of the one the developer's
+    /// terminal happens to support.
+    ///
+    /// `App::new` builds its theme with `Theme::from_config`, which ends in
+    /// `adapt(detect_depth())` — a read of `COLORTERM` and `TERM`. Several
+    /// tests below assert that two roles render in DIFFERENT colors, and that
+    /// is only true of the authored palette: downgraded to 16 colors, distinct
+    /// RGB roles legitimately collapse onto the same slot, and `assert_ne!`
+    /// fails with the two sides printing identically. A renderer test must test
+    /// the renderer, not the terminal it is being run from.
+    fn pin_theme(app: &mut App) {
+        let theme = crate::render::theme::Theme::authored(&app.config.theme).unwrap();
+        app.theme = theme;
     }
 
     fn render_to(app: &App, w: u16, h: u16) -> ratatui::buffer::Buffer {
@@ -1528,6 +1544,7 @@ mod tests {
         std::fs::write(&note, body).unwrap();
 
         let mut app = App::new(Config::default(), Some(note), None).unwrap();
+        pin_theme(&mut app);
         app.embed_mode = crate::transclude::Mode::Short;
         app.refresh_blocks();
         (d, app)

--- a/src/render/theme.rs
+++ b/src/render/theme.rs
@@ -621,14 +621,31 @@ mod tests {
 
         // Then wholesale, which is what catches a role the file OMITS — the
         // per-key loop can only check the keys that are there.
+        // AUTHORED, not `from_config`: the latter ends with `adapt(detect_depth())`,
+        // so it answers with the palette the DEVELOPER'S terminal can show while
+        // `Theme::default()` is always the authored one. On a 16-color terminal
+        // — which is what a CI runner is, with no COLORTERM and no TERM — every
+        // role downgrades onto an indexed slot and the two sides cannot match.
+        // The question this test asks is about two authored palettes; the
+        // terminal has no business in the answer.
         assert!(
-            Theme::from_config(&cfg).unwrap() == Theme::default(),
+            Theme::authored(&cfg).unwrap() == Theme::default(),
             "shoin/theme.conf and Theme::default() disagree — change both, or neither"
         );
     }
 
+    /// Overlaying is `authored`'s job — `from_config` is `authored` plus a
+    /// downgrade for the terminal — so this asks `authored` and gets the same
+    /// answer on every machine.
+    ///
+    /// It used to ask `from_config` and wrap the color assertions in
+    /// `if detect_depth() == TrueColor`, which meant they simply did not run on
+    /// a 256-color terminal, while the unguarded `background` line compared an
+    /// ADAPTED color against an unadapted `Theme::default()` and failed outright
+    /// anywhere below truecolor. A test that skips itself on one machine and
+    /// fails on another is worse than no test.
     #[test]
-    fn from_config_overlays_colors_and_styles() {
+    fn authored_overlays_colors_and_styles() {
         let toml = r##"
             text = "#010203"
             heading_1 = "#0a0b0c"
@@ -637,16 +654,24 @@ mod tests {
             heading_bold = false
         "##;
         let cfg: ThemeConfig = toml::from_str(toml).unwrap();
-        let theme = Theme::from_config(&cfg).unwrap();
-        // Overlaid over the default, in a truecolor test run.
-        if detect_depth() == ColorDepth::TrueColor {
-            assert_eq!(theme.text, Color::Rgb(1, 2, 3));
-            assert_eq!(theme.headings[0], Color::Rgb(0x0a, 0x0b, 0x0c));
-            assert_eq!(theme.indent_colors.len(), 2);
-        }
+        let theme = Theme::authored(&cfg).unwrap();
+        assert_eq!(theme.text, Color::Rgb(1, 2, 3));
+        assert_eq!(theme.headings[0], Color::Rgb(0x0a, 0x0b, 0x0c));
+        assert_eq!(theme.indent_colors.len(), 2);
         assert!(!theme.heading_bold);
         // A key we didn't set keeps the default.
         assert_eq!(theme.background, Theme::default().background);
+    }
+
+    /// …and `from_config` is exactly that, downgraded — which is the half the
+    /// test above deliberately leaves out, pinned here to a depth rather than
+    /// read from the environment.
+    #[test]
+    fn from_config_is_authored_then_adapted() {
+        let cfg = ThemeConfig::default();
+        let mut expected = Theme::authored(&cfg).unwrap();
+        expected.adapt(detect_depth());
+        assert!(Theme::from_config(&cfg).unwrap() == expected);
     }
 
     #[test]

--- a/src/text/object.rs
+++ b/src/text/object.rs
@@ -233,8 +233,14 @@ fn quote(buffer: &Buffer, cursor: Cursor, q: char, around: bool) -> Option<Objec
         .map(|(i, _)| i)
         .collect();
 
+    // `as_chunks::<2>()` rather than `chunks_exact(2)`: the items are
+    // `&[usize; 2]`, so `c[0]` and `c[1]` are checked when this compiles instead
+    // of at each call. `.1` is the odd trailing quote, which has no partner and
+    // so bounds nothing.
     let (open, close) = marks
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| (c[0], c[1]))
         .find(|(_, close)| cursor.col <= *close)?;
 


### PR DESCRIPTION
CI was red on both Linux and macOS while `cargo test` passed locally, which is
the signature of a test that consults its environment.

`Theme::from_config` ends in `adapt(detect_depth())`, and `detect_depth` reads
COLORTERM then TERM — the one environment check in the program. A CI runner has
neither, so it is a 16-color terminal, and four tests were asking questions
whose answers depend on that:

  * `the_shipped_theme_matches_the_built_in_default` compared `from_config`
    (adapted) against `Theme::default()` (authored). Below truecolor those are
    two different palettes by construction.

  * `from_config_overlays_colors_and_styles` had the same mismatch on its
    `background` line, and — worse — guarded its color assertions with
    `if detect_depth() == TrueColor`, so on a 256-color terminal they did not
    run at all. A test that skips itself on one machine and fails on another is
    worse than no test.

  * The two frame tests assert with `assert_ne!` that two roles render in
    different colors. Downgraded to 16 colors, distinct RGB roles legitimately
    collapse onto one slot, and the assertion failed printing `Indexed(0)` on
    both sides — the failure message reading as though a value differed from
    itself.

The fix is to ask the right question rather than to set COLORTERM in CI.
Overlaying is `authored`'s job and downgrading is `from_config`'s, so the two
theme tests use `authored` and the frame tests pin the authored palette onto
the app before rendering. A renderer test tests the renderer, not the terminal
it is being run from; a palette test compares two authored palettes.

`from_config_is_authored_then_adapted` is new and covers the half that was
dropped: that `from_config` really is `authored` plus the downgrade.

Verified under four environments, 440 tests green in each: no COLORTERM and no
TERM (what CI has), truecolor, xterm-256color, and TERM=dumb. Before this
commit the first, third and fourth all failed.
