### PR TITLE
Stop wrapping table rows

### DIFF
--- a/src/render/cache.rs
+++ b/src/render/cache.rs
@@ -25,7 +25,7 @@ use crate::app::{App, BufferState};
 use crate::config::schema::{GlyphConfig, MarkdownConfig};
 use crate::render::conceal::{ConcealCtx, ConcealMap};
 use crate::render::indent::{self, guides_for};
-use crate::render::layout::{content_column, wrap_hanging, RowSource, VisualRow};
+use crate::render::layout::{content_column, no_wrap, wrap_hanging, RowSource, VisualRow};
 use crate::render::markdown::{self, block::BlockKind};
 use crate::render::theme::Theme;
 use crate::transclude::preview::Expansion;
@@ -521,9 +521,22 @@ fn build(app: &App, doc: &BufferState, line: usize, block: BlockKind, measure: u
         None
     };
 
+    // A table row's `|` columns are laid out by its author, in the source; word
+    // wrap would break that layout onto several ragged rows instead of leaving
+    // it aligned. Overflow past the measure is clipped at the pane edge, same
+    // as any other unwrapped line.
+    let (wrap_raw, wrap_concealed) = if block == BlockKind::Table {
+        (no_wrap(&source), no_wrap(&concealed))
+    } else {
+        (
+            wrap_hanging(&source, measure, hang_raw),
+            wrap_hanging(&concealed, measure, hang_concealed),
+        )
+    };
+
     LineEntry {
-        wrap_raw: wrap_hanging(&source, measure, hang_raw),
-        wrap_concealed: wrap_hanging(&concealed, measure, hang_concealed),
+        wrap_raw,
+        wrap_concealed,
         source,
         block,
         styled,

--- a/src/render/frame.rs
+++ b/src/render/frame.rs
@@ -2513,5 +2513,24 @@ mod tests {
         assert!(joined.contains("# One"));
         assert!(joined.contains("## Two"), "conceal off: line 1 keeps its ##");
     }
+
+    /// A table row's `|` columns are laid out by its author, not by wrapping —
+    /// a row wider than the measure stays one row, clipped at the edge, rather
+    /// than breaking onto ragged continuation lines that no longer align.
+    #[test]
+    fn a_wide_table_row_does_not_wrap() {
+        let md = "| Name | Description | Owner |\n|---|---|---|\n| alpha | a long description that will not fit in a narrow measure | bob |\n";
+        let app = app_with(md);
+        let buf = render_to(&app, 40, 12);
+        let text = rows(&buf);
+        assert!(
+            text.iter().any(|r| r.contains("| alpha | a long description")),
+            "the row's start is on screen, unbroken: {text:?}"
+        );
+        assert!(
+            !text.iter().any(|r| r.trim() == "bob |"),
+            "the row's tail must not have wrapped onto its own line: {text:?}"
+        );
+    }
 }
 

--- a/src/render/layout.rs
+++ b/src/render/layout.rs
@@ -251,6 +251,16 @@ pub fn wrap_line(text: &str, measure: u16) -> Vec<(usize, usize)> {
     out
 }
 
+/// A line that never wraps: one range, covering the whole line.
+///
+/// A table row's columns are aligned by `|`s the author placed in the source;
+/// word-wrapping it the way a paragraph wraps would break that alignment onto
+/// several ragged rows, which is worse than the row running past the measure
+/// and getting clipped at the pane edge like any other unwrapped overflow.
+pub fn no_wrap(text: &str) -> Vec<(usize, usize)> {
+    vec![(0, text.chars().count())]
+}
+
 /// The single funnel for measuring a line in display cells.
 pub fn display_width(text: &str) -> u16 {
     text.chars()


### PR DESCRIPTION
## Summary
Table rows were word-wrapped like paragraphs, breaking their `|` columns onto several ragged lines when a row was wider than the pane. Table rows now render as a single row and clip at the pane edge instead.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`