### PR TITLE
Add a shortcuts help page, bound to <leader>hl

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ frame.
 
 Then, in order: `i` to type, `Esc` to stop, `:w` to save, `:q` to quit. And
 **`:help`** inside the editor explains everything else — `:help bindings`,
-`:help commands`, `:help writer`, `:help config`.
+`:help commands`, `:help writer`, `:help config`. `<leader>hl` (or
+`:help shortcuts`) opens a single page listing every keyboard interaction —
+leader keys, `:` commands, navigation and other keybindings — grouped by kind.
 
 ---
 

--- a/shoin/keys.conf
+++ b/shoin/keys.conf
@@ -23,6 +23,7 @@
 "<leader>t"  = "toggle_typewriter"
 "<leader>z"  = "toggle_zen"
 "<leader>c"  = "toggle_conceal"
+"<leader>hl" = "help"            # the shortcuts/keybindings reference page
 # Inside the tree, `-` re-roots one level up and `+` into the selected dir.
 "<leader>fe" = "file_tree"       # file tree in the edited file's folder
 "<leader>fE" = "file_tree_home"  # file tree over $HOME

--- a/src/app.rs
+++ b/src/app.rs
@@ -1641,6 +1641,10 @@ impl App {
                 let root = self.root_dir(root);
                 self.toggle_tree(root);
             }
+            // Not toggle symmetry: once open, the overlay owns all input
+            // (`on_key_help`), so a repeat of this binding never reaches here
+            // to close it — q / Esc does that, same as `:help` opened it.
+            Action::Help => self.open_help("shortcuts"),
             Action::FollowLink => self.follow_link(),
             Action::OpenExternal => self.open_external(),
             Action::AlternateBuffer => self.alternate_buffer(),
@@ -6538,6 +6542,18 @@ mod tests {
         let mut app = app_with_keys("word\n", &[("<leader>b", "toggle_bold")]);
         feed(&mut app, " b"); // <leader>b
         assert_eq!(text(&app), "**word**\n");
+    }
+
+    /// `<leader>hl` opens the shortcuts reference. Once open it owns all
+    /// input (like `:help`), so `q` is what closes it, not a second press.
+    #[test]
+    fn leader_hl_opens_the_shortcuts_help() {
+        let mut app = app_with_keys("word\n", &[("<leader>hl", "help")]);
+        feed(&mut app, " hl");
+        assert_eq!(app.help.as_ref().map(|h| h.title.as_str()), Some("shortcuts"));
+
+        feed(&mut app, "q");
+        assert!(app.help.is_none(), "q closes it");
     }
 
     fn cmd(app: &mut App, line: &str) {

--- a/src/help.rs
+++ b/src/help.rs
@@ -14,6 +14,7 @@ impl Help {
         let key = topic.trim().to_ascii_lowercase();
         let (title, lines): (&str, Vec<&str>) = match key.as_str() {
             "" | "overview" | "help" => ("help", OVERVIEW.to_vec()),
+            "shortcuts" | "reference" | "cheatsheet" | "cheat" => ("shortcuts", SHORTCUTS.to_vec()),
             "bindings" | "keys" | "keymap" | "keymaps" | "motions" => ("bindings", BINDINGS.to_vec()),
             "commands" | "command" | "ex" => ("commands", COMMANDS.to_vec()),
             "writer" | "verbs" | "markdown" | "format" => ("writer verbs", WRITER.to_vec()),
@@ -35,6 +36,7 @@ fn unknown(topic: &str) -> Vec<&'static str> {
     v.extend_from_slice(&[
         "Available topics:",
         "  :help              this overview",
+        "  :help shortcuts    every keyboard interaction, by category",
         "  :help bindings     keys, motions, operators",
         "  :help commands     the : (ex) commands",
         "  :help writer       bold / italic / headings / tasks",
@@ -93,10 +95,67 @@ const OVERVIEW: &[&str] = &[
     "  Enter  Esc         open the selected file · close the finder",
     "",
     "MORE HELP",
+    "  <leader>hl         every keyboard interaction, by category",
     "  :help bindings     the full key list",
     "  :help commands     every : command",
     "  :help writer       Markdown formatting verbs (g...)",
     "  :help config       config file location and settings",
+    "",
+    "Scroll with j/k or the arrows. Press q or Esc to close.",
+];
+
+/// Every keyboard interaction shoin answers to, grouped by KIND rather than by
+/// what it is used for — one page to scan top to bottom, opened with
+/// `<leader>hl` or `:help shortcuts`. `:help bindings` covers the Vim grammar
+/// (motions, operators, text objects) in more depth; this page is the map of
+/// where everything lives.
+const SHORTCUTS: &[&str] = &[
+    "SHORTCUTS — every keyboard interaction, by kind",
+    "",
+    "<leader> KEYS  (leader is Space by default — [input].leader)",
+    "  <leader>hl     this page",
+    "  <leader>w      save                    <leader>q      quit",
+    "  <leader>F      cycle focus mode        <leader>t      typewriter scroll",
+    "  <leader>z      toggle zen (all chrome) <leader>c      toggle conceal",
+    "  <leader>fe     file tree, this folder  <leader>fE     file tree, $HOME",
+    "  <leader>ff     find file, this folder  <leader>fF     find file, $HOME",
+    "  <leader>fb     switch buffer (finder)",
+    "  <leader>sv     split beside / close    <leader>ss     split below / close",
+    "  <leader>so     keep only this pane",
+    "  <leader>b      toggle **bold**  (Visual mode only)",
+    "  <leader>i      toggle *italic*  (Visual mode only)",
+    "  These are the shipped defaults (shoin/keys.conf) — remap any of them, or",
+    "  add more, under [keys.normal] / [keys.visual]. See :help config.",
+    "",
+    ": COMMANDS  (type : then the command, Enter to run — :help commands for all)",
+    "  :w  :q  :wq          save / close / both        :Q  :qa      quit all",
+    "  :e <path>            open a file                :help [topic] this help",
+    "  :sp  :vs  :close  :only                          split / close panes",
+    "  :ls  :b <name>  :bn  :bp  :bd                     buffers",
+    "  :diff  :revert  :export [fmt]                     merge / reload / export",
+    "  :set <key> [value]   settings, e.g. measure, autosave, line_spacing",
+    "  :embed [mode]        how much of ![[...]] to expand in place",
+    "",
+    "NAVIGATION  (motions — take a count, e.g. 3w; also see :help bindings)",
+    "  h j k l        left / down / up / right (arrows work too)",
+    "  w b e  W B E   word forward / back / end (W/B/E = whitespace-delimited)",
+    "  0 ^ $          line start / first non-blank / end",
+    "  { }            previous / next paragraph        gg G   top / bottom",
+    "  f{c} t{c}      find / till char (F/T backward);  ; ,   repeat / reverse",
+    "  H M L          top / middle / bottom of the visible screen",
+    "  Ctrl-d/u/f/b   half page / full page down / up",
+    "  gf  gx         follow a link · open it externally",
+    "",
+    "KEYBINDINGS  (single/doubled keys — the Vim grammar, :help bindings for all)",
+    "  i a I A o O    insert / append / line start / line end / open below/above",
+    "  d c y  dd cc yy  operators — delete / change / yank, doubled = whole line",
+    "  x X D C Y      delete char / before / to-eol / change-to-eol / yank-line",
+    "  p P            paste after / before             u  Ctrl-r  undo / redo",
+    "  v V            Visual charwise / linewise        .   repeat last change",
+    "  / ?  n N       search forward / back / repeat    :   command line",
+    "  g1..g6 g0      set / clear heading level         gb gi gh gk  bold/italic/",
+    "                                                    highlight/code (writer)",
+    "  Ctrl-w h j k l v s q o  window: move / split / close / cycle pane",
     "",
     "Scroll with j/k or the arrows. Press q or Esc to close.",
 ];
@@ -266,8 +325,8 @@ const COMMANDS: &[&str] = &[
     "  :set line_spacing=1   blank rows between lines, 0-4",
     "",
     "HELP",
-    "  :help [topic]         this help — topics: bindings, commands,",
-    "                        writer, config",
+    "  :help [topic]         this help — topics: shortcuts, bindings,",
+    "                        commands, writer, config",
 ];
 
 const WRITER: &[&str] = &[
@@ -346,12 +405,27 @@ mod tests {
     #[test]
     fn resolves_topics_and_aliases() {
         assert_eq!(Help::open("").title, "help");
+        assert_eq!(Help::open("shortcuts").title, "shortcuts");
+        assert_eq!(Help::open("cheatsheet").title, "shortcuts"); // alias
         assert_eq!(Help::open("bindings").title, "bindings");
         assert_eq!(Help::open("keys").title, "bindings"); // alias
         assert_eq!(Help::open("commands").title, "commands");
         assert_eq!(Help::open("writer").title, "writer verbs");
         assert_eq!(Help::open("config").title, "config");
         assert!(!Help::open("bindings").lines.is_empty());
+        assert!(!Help::open("shortcuts").lines.is_empty());
+    }
+
+    /// The shortcuts page is the one place all four kinds of interaction are
+    /// listed together — the thing `<leader>hl` exists to open.
+    #[test]
+    fn shortcuts_page_covers_every_kind() {
+        let h = Help::open("shortcuts");
+        assert!(h.lines.iter().any(|l| l.contains("<leader> KEYS")));
+        assert!(h.lines.iter().any(|l| l.contains(": COMMANDS")));
+        assert!(h.lines.iter().any(|l| l.contains("NAVIGATION")));
+        assert!(h.lines.iter().any(|l| l.contains("KEYBINDINGS")));
+        assert!(h.lines.iter().any(|l| l.contains("<leader>hl")));
     }
 
     #[test]

--- a/src/input/action.rs
+++ b/src/input/action.rs
@@ -122,6 +122,11 @@ pub enum Action {
     /// alternate file, and the way back out of a followed link.
     AlternateBuffer,
 
+    /// Open the shortcuts/keybindings reference overlay (`:help shortcuts`,
+    /// one key away). `:help [topic]` reaches the same overlay for any topic;
+    /// q / Esc closes it, same as it closes `:help`.
+    Help,
+
     /// `gf` — open what the cursor is on: a `[[note]]`, an unexpanded
     /// `![[embed]]`, or the path in a `[text](path)`. A note that does not
     /// exist yet is CREATED — in a vault, the link is written before the note.
@@ -186,6 +191,7 @@ impl Action {
             "toggle_typewriter" | "typewriter" => Action::ToggleTypewriter,
             "toggle_conceal" | "conceal" => Action::ToggleConceal,
             "toggle_zen" | "zen" => Action::ToggleZen,
+            "help" | "shortcuts" => Action::Help,
             "file_tree" | "file_explorer" | "tree" => Action::FileTree { root: Root::File },
             "file_tree_home" | "file_explorer_home" => Action::FileTree { root: Root::Home },
             "find_file" | "fuzzy_find" | "files" => Action::FindFile { root: Root::File },


### PR DESCRIPTION
## Summary
- Adds a `:help shortcuts` page (aliases: `reference`, `cheatsheet`, `cheat`) listing every keyboard interaction — leader keys, `:` commands, navigation, and other keybindings — grouped by kind on one page.
- Binds it to `<leader>hl` by default (`shoin/keys.conf`), reusing the existing help overlay (q/Esc to close, j/k to scroll).
- `:help` and its other topics are unchanged; the overview and command list now point at the new page too.

## Test plan
- [x] `cargo test`
- [x] `cargo clippy --all-targets -- -D warnings`